### PR TITLE
Possible different backends for Taxon

### DIFF
--- a/taxon/backends.py
+++ b/taxon/backends.py
@@ -1,0 +1,155 @@
+import hashlib
+from functools import partial
+from itertools import imap
+from .query import Query, sexpr
+
+
+class Backend(object):
+    def __init__(self):
+        pass
+
+    def tag_items(self, tag, *items):
+        raise NotImplementedError
+
+    def untag_items(self, tag, *items):
+        raise NotImplementedError
+
+    def remove_items(self, *items):
+        raise NotImplementedError
+
+    def all_tags(self):
+        raise NotImplementedError
+
+    def all_items(self):
+        raise NotImplementedError
+
+    def query(self, q):
+        raise NotImplementedError
+
+
+class RedisBackend(Backend):
+    def __init__(self, redis, name='txn'):
+        self._r = redis
+        self._name = name
+        make_key = partial(lambda *parts: ':'.join(parts), self._name)
+        self.tag_key = partial(make_key, 'tag')
+        self.result_key = partial(make_key, 'result')
+        self.items_key = make_key('items')
+        self.tags_key = make_key('tags')
+        self.cache_key = make_key('cache')
+
+    @property
+    def redis(self):
+        return self._r
+
+    @property
+    def name(self):
+        return self._name
+
+    def encode(self, data):
+        return str(data)
+
+    def decode(self, data):
+        return str(data)
+
+    def tag_items(self, tag, *items):
+        items = list(set(self.encode(item) for item in items) - self._r.smembers(self.tag_key(tag)))
+        if len(items) == 0:
+            raise ValueError("either no items provided or all exist in tag")
+        with self._r.pipeline() as pipe:
+            pipe.zincrby(self.tags_key, tag, len(items))
+            pipe.sadd(self.tag_key(tag), *items)
+            for item in items:
+                pipe.zincrby(self.items_key, item, 1)
+            pipe.execute()
+        return items
+
+    def untag_items(self, tag, *items):
+        items = list(set(self.encode(item) for item in items) & self._r.smembers(self.tag_key(tag)))
+        if len(items) == 0:
+            raise ValueError("either no items provided or none exist in tag")
+        with self._r.pipeline() as pipe:
+            pipe.zincrby(self.tags_key, tag, -len(items))
+            pipe.srem(self.tag_key(tag), *items)
+            for item in items:
+                pipe.zincrby(self.items_key, item, -1)
+            pipe.execute()
+        self._clear_cache()
+        return items
+
+    def remove_items(self, *items):
+        if not len(items):
+            return ValueError("must remove at least 1 item")
+        removed = 0
+        for item in imap(self.encode, items):
+            score = self._r.zscore(self.items_key, item)
+            if not score:
+                continue
+            for tag in self.all_tags():
+                srem_ok = self._r.srem(self.tag_key(tag), item)
+                if not srem_ok:
+                    continue
+                with self._r.pipeline() as pipe:
+                    pipe.zincrby(self.tags_key, tag, -1)
+                    pipe.zincrby(self.items_key, item, -1)
+                    pipe.execute()
+            removed += 1
+        self._clear_cache()
+        return removed
+
+    def all_tags(self):
+        return list(self._r.zrangebyscore(self.tags_key, 1, '+inf'))
+
+    def all_items(self):
+        return map(self.decode, self._r.zrangebyscore(self.items_key, 1, '+inf'))
+
+    def query(self, q):
+        if isinstance(q, Query):
+            return self._raw_query(*q.freeze().items()[0])
+        elif isinstance(q, dict):
+            return self._raw_query(*q.items()[0])
+        else:
+            raise TypeError("%s is not a recognized Taxon query" % q)
+
+    def _raw_query(self, fn, args):
+        "Perform a raw query on the Taxon instance"
+        h = hashlib.sha1(sexpr({fn: args[:]}))
+        keyname = self.result_key(h.hexdigest())
+        if self._r.exists(keyname):
+            return (keyname, map(self.decode, self._r.smembers(keyname)))
+
+        if fn == 'tag':
+            if len(args) == 1:
+                key = self.tag_key(args[0])
+                return (key, map(self.decode, self._r.smembers(key)))
+            else:
+                keys = [self.tag_key(k) for k in args]
+                self._r.sunionstore(keyname, *keys)
+                self._r.sadd(self.cache_key, keyname)
+                return (keyname, map(self.decode, self._r.smembers(keyname)))
+        elif fn == 'and':
+            interkeys = [key for key, _ in [self._raw_query(*a.items()[0]) for a in args]]
+            self._r.sinterstore(keyname, *interkeys)
+            self._r.sadd(self.cache_key, keyname)
+            return (keyname, map(self.decode, self._r.smembers(keyname)))
+        elif fn == 'or':
+            interkeys = [key for key, _ in [self._raw_query(*a.items()[0]) for a in args]]
+            self._r.sunionstore(keyname, *interkeys)
+            self._r.sadd(self.cache_key, keyname)
+            return (keyname, map(self.decode, self._r.smembers(keyname)))
+        elif fn == 'not':
+            interkeys = [key for key, _ in [self._raw_query(*a.items()[0]) for a in args]]
+            tags = self.all_tags()
+            scratchpad_key = self.result_key('_')
+            self._r.sunionstore(scratchpad_key, *map(self.tag_key, tags))
+            self._r.sdiffstore(keyname, scratchpad_key, *interkeys)
+            self._r.sadd(self.cache_key, keyname)
+            return (keyname, map(self.decode, self._r.smembers(keyname)))
+        else:
+            raise SyntaxError("Unkown Taxon operator '%s'" % fn)
+
+    def _clear_cache(self):
+        cached_keys = self._r.smembers(self.cache_key)
+        if len(cached_keys) > 0:
+            self._r.delete(*cached_keys)
+        return True

--- a/taxon/core.py
+++ b/taxon/core.py
@@ -1,7 +1,5 @@
-import hashlib
-from functools import partial
-from itertools import imap
-from .query import Query, sexpr
+from .backends import Backend
+from .query import Query
 
 
 class Taxon(object):
@@ -10,138 +8,37 @@ class Taxon(object):
     by tag.
     """
 
-    def __init__(self, redis, name='txn'):
-        self._r = redis
-        self._name = name
-        make_key = partial(lambda *parts: ':'.join(parts), self._name)
-        self.tag_key = partial(make_key, 'tag')
-        self.result_key = partial(make_key, 'result')
-        self.items_key = make_key('items')
-        self.tags_key = make_key('tags')
-        self.cache_key = make_key('cache')
-
-    def encode(self, data):
-        return str(data)
-
-    def decode(self, data):
-        return str(data)
-
-    @property
-    def redis(self):
-        return self._r
-
-    @property
-    def name(self):
-        return self._name
+    def __init__(self, backend):
+        if not isinstance(backend, Backend):
+            raise ValueError("%s is not a valid backend" % backend)
+        self._backend = backend
 
     def tag(self, tag, *items):
-        "Store ``items`` in Redis tagged with ``tag``"
-        items = list(set(self.encode(item) for item in items) - self._r.smembers(self.tag_key(tag)))
-        if len(items) == 0:
-            raise ValueError("either no items provided or all exist in tag")
-        with self._r.pipeline() as pipe:
-            pipe.zincrby(self.tags_key, tag, len(items))
-            pipe.sadd(self.tag_key(tag), *items)
-            for item in items:
-                pipe.zincrby(self.items_key, item, 1)
-            pipe.execute()
-        return items
+        "Add tag to items"
+        return self._backend.tag_items(tag, *items)
 
     def untag(self, tag, *items):
-        "Remove tag ``tag`` from items ``items``"
-        items = list(set(self.encode(item) for item in items) & self._r.smembers(self.tag_key(tag)))
-        if len(items) == 0:
-            raise ValueError("either no items provided or none exist in tag")
-        with self._r.pipeline() as pipe:
-            pipe.zincrby(self.tags_key, tag, -len(items))
-            pipe.srem(self.tag_key(tag), *items)
-            for item in items:
-                pipe.zincrby(self.items_key, item, -1)
-            pipe.execute()
-        self._clear_cache()
-        return items
+        "Remove tag from items"
+        return self._backend.untag_items(tag, *items)
 
     def remove(self, *items):
-        "Remove items from the instance"
-        if not len(items):
-            return ValueError("must remove at least 1 item")
-        removed = 0
-        for item in imap(self.encode, items):
-            score = self._r.zscore(self.items_key, item)
-            if not score:
-                continue
-            for tag in self.tags():
-                srem_ok = self._r.srem(self.tag_key(tag), item)
-                if not srem_ok:
-                    continue
-                with self._r.pipeline() as pipe:
-                    pipe.zincrby(self.tags_key, tag, -1)
-                    pipe.zincrby(self.items_key, item, -1)
-                    pipe.execute()
-            removed += 1
-        self._clear_cache()
-        return removed
+        "Remove items"
+        return self._backend.remove_items(*items)
 
     def tags(self):
-        "Return the set of all tags known to the instance"
-        return list(self._r.zrangebyscore(self.tags_key, 1, '+inf'))
+        "Return the collection of all known tags"
+        return self._backend.all_tags()
 
     def items(self):
-        "Return the set of all tagged items known to the instance"
-        return map(self.decode, self._r.zrangebyscore(self.items_key, 1, '+inf'))
+        "Return the collection of all known items"
+        return self._backend.all_items()
 
     def query(self, q):
-        "Perform a query on the Taxon instance"
-        if isinstance(q, Query):
-            return self._raw_query(*q.freeze().items()[0])
-        elif isinstance(q, dict):
-            return self._raw_query(*q.items()[0])
-        else:
-            raise TypeError("%s is not a recognized Taxon query" % q)
+        "Perform a query and return the results and metadata"
+        if not isinstance(q, (dict, Query)):
+            raise ValueError("%s is not a valid query" % q)
+        return self._backend.query(q)
 
     def find(self, q):
         _, items = self.query(q)
         return set(items)
-
-    def _raw_query(self, fn, args):
-        "Perform a raw query on the Taxon instance"
-        h = hashlib.sha1(sexpr({fn: args[:]}))
-        keyname = self.result_key(h.hexdigest())
-        if self._r.exists(keyname):
-            return (keyname, map(self.decode, self._r.smembers(keyname)))
-
-        if fn == 'tag':
-            if len(args) == 1:
-                key = self.tag_key(args[0])
-                return (key, map(self.decode, self._r.smembers(key)))
-            else:
-                keys = [self.tag_key(k) for k in args]
-                self._r.sunionstore(keyname, *keys)
-                self._r.sadd(self.cache_key, keyname)
-                return (keyname, map(self.decode, self._r.smembers(keyname)))
-        elif fn == 'and':
-            interkeys = [key for key, _ in [self._raw_query(*a.items()[0]) for a in args]]
-            self._r.sinterstore(keyname, *interkeys)
-            self._r.sadd(self.cache_key, keyname)
-            return (keyname, map(self.decode, self._r.smembers(keyname)))
-        elif fn == 'or':
-            interkeys = [key for key, _ in [self._raw_query(*a.items()[0]) for a in args]]
-            self._r.sunionstore(keyname, *interkeys)
-            self._r.sadd(self.cache_key, keyname)
-            return (keyname, map(self.decode, self._r.smembers(keyname)))
-        elif fn == 'not':
-            interkeys = [key for key, _ in [self._raw_query(*a.items()[0]) for a in args]]
-            tags = self.tags()
-            scratchpad_key = self.result_key('_')
-            self._r.sunionstore(scratchpad_key, *map(self.tag_key, tags))
-            self._r.sdiffstore(keyname, scratchpad_key, *interkeys)
-            self._r.sadd(self.cache_key, keyname)
-            return (keyname, map(self.decode, self._r.smembers(keyname)))
-        else:
-            raise SyntaxError("Unkown Taxon operator '%s'" % fn)
-
-    def _clear_cache(self):
-        cached_keys = self._r.smembers(self.cache_key)
-        if len(cached_keys) > 0:
-            self._r.delete(*cached_keys)
-        return True

--- a/taxon/core.py
+++ b/taxon/core.py
@@ -42,3 +42,6 @@ class Taxon(object):
     def find(self, q):
         _, items = self.query(q)
         return set(items)
+
+    def empty(self):
+        return self._backend.empty()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,114 +1,153 @@
+from functools import partial
 from redis import Redis
-from nose.tools import with_setup, raises, eq_, ok_
+from nose.tools import raises, eq_, ok_
 from .context import taxon
-from taxon.backends import RedisBackend
+from taxon.backends import MemoryBackend, RedisBackend
 from taxon.query import *
 
-t = None
-db = 9
+redis_inst = Redis(db=9)
+TestRedisBackend = partial(RedisBackend, redis_inst)
 
 
 def setup():
-    global t, db
-    t = taxon.Taxon(RedisBackend(Redis(db=db)))
-    if t._backend.redis.dbsize() > 0:
-        raise RuntimeError("Redis DB %d is not empty" % db)
+    global redis_inst
+    if redis_inst.dbsize() > 0:
+        raise RuntimeError("Redis DB is not empty")
 
 
 def teardown():
-    global t
-    t._backend.redis.flushdb()
+    global redis_inst
+    redis_inst.flushdb()
 
 
-@with_setup(teardown=teardown)
 def simple_add_test():
-    t.tag('foo', 'a')
-    t.tag('bar', 'b')
-    t.tag('bar', 'c')
-    eq_(set(t.tags()), set(['foo', 'bar']))
-    eq_(set(t.items()), set(['a', 'b', 'c']))
+    def func(t):
+        t.tag('foo', 'a')
+        t.tag('bar', 'b')
+        t.tag('bar', 'c')
+        eq_(set(t.tags()), set(['foo', 'bar']))
+        eq_(set(t.items()), set(['a', 'b', 'c']))
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def complex_add_test():
-    t.tag('foo', 'a')
-    t.tag('bar', 'b', 'c')
-    eq_(set(t.tags()), set(['foo', 'bar']))
-    eq_(set(t.items()), set(['a', 'b', 'c']))
+    def func(t):
+        t.tag('foo', 'a')
+        t.tag('bar', 'b', 'c')
+        eq_(set(t.tags()), set(['foo', 'bar']))
+        eq_(set(t.items()), set(['a', 'b', 'c']))
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def tag_query_test():
-    t.tag('foo', 'a', 'b', 'c')
-    _, items = t.query(Tag("foo"))
-    eq_(set(items), set(['a', 'b', 'c']))
+    def func(t):
+        t.tag('foo', 'a', 'b', 'c')
+        _, items = t.query(Tag("foo"))
+        eq_(set(items), set(['a', 'b', 'c']))
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def simple_remove_test():
-    t.tag('foo', 'a')
-    t.tag('bar', 'b', 'c')
-    eq_(set(t.tags()), set(['foo', 'bar']))
-    eq_(set(t.items()), set(['a', 'b', 'c']))
-    t.untag('bar', 'b')
-    eq_(set(t.tags()), set(['foo', 'bar']))
-    _, items = t.query(Tag('bar'))
-    eq_(set(items), set(['c']))
-    t.untag('bar', 'c')
-    eq_(set(t.tags()), set(['foo']))
-    _, items = t.query(Tag('bar'))
-    eq_(set(items), set([]))
+    def func(t):
+        t.tag('foo', 'a')
+        t.tag('bar', 'b', 'c')
+        eq_(set(t.tags()), set(['foo', 'bar']))
+        eq_(set(t.items()), set(['a', 'b', 'c']))
+        t.untag('bar', 'b')
+        eq_(set(t.tags()), set(['foo', 'bar']))
+        _, items = t.query(Tag('bar'))
+        eq_(set(items), set(['c']))
+        t.untag('bar', 'c')
+        eq_(set(t.tags()), set(['foo']))
+        _, items = t.query(Tag('bar'))
+        eq_(set(items), set([]))
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def remove_item_test():
-    t.tag('foo', 'a')
-    t.tag('bar', 'a')
-    t.tag('baz', 'a')
-    eq_(len(t.tags()), 3)
-    eq_(len(t.items()), 1)
-    eq_(t.remove('a'), 1)
-    eq_(len(t.tags()), 0)
-    eq_(len(t.items()), 0)
+    def func(t):
+        t.tag('foo', 'a')
+        t.tag('bar', 'a')
+        t.tag('baz', 'a')
+        eq_(len(t.tags()), 3)
+        eq_(len(t.items()), 1)
+        eq_(set(t.remove('a')), set(['a']))
+        eq_(len(t.tags()), 0)
+        eq_(len(t.items()), 0)
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def find_test():
-    t.tag('foo', 'a', 'b')
-    results = t.find(Tag('foo'))
-    eq_(results, set(['a', 'b']))
+    def func(t):
+        t.tag('foo', 'a', 'b')
+        results = t.find(Tag('foo'))
+        eq_(results, set(['a', 'b']))
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def and_query_test():
-    t.tag('foo', 'a', 'b')
-    t.tag('bar', 'a', 'c')
-    _, items = t.query(And('foo', 'bar'))
-    eq_(set(items), set(['a']))
+    def func(t):
+        t.tag('foo', 'a', 'b')
+        t.tag('bar', 'a', 'c')
+        _, items = t.query(And('foo', 'bar'))
+        eq_(set(items), set(['a']))
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def or_query_test():
-    t.tag('foo', 'a', 'b')
-    t.tag('bar', 'a', 'c')
-    _, items = t.query(Or('foo', 'bar'))
-    eq_(set(items), set(['a', 'b', 'c']))
+    def func(t):
+        t.tag('foo', 'a', 'b')
+        t.tag('bar', 'a', 'c')
+        _, items = t.query(Or('foo', 'bar'))
+        eq_(set(items), set(['a', 'b', 'c']))
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def not_query_test():
-    t.tag('foo', 'a', 'b')
-    t.tag('bar', 'a', 'c')
-    _, items = t.query(Not('foo'))
-    eq_(set(items), set(['c']))
+    def func(t):
+        t.tag('foo', 'a', 'b')
+        t.tag('bar', 'a', 'c')
+        _, items = t.query(Not('foo'))
+        eq_(set(items), set(['c']))
+        t.empty()
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@raises(TypeError)
 def invalid_type_in_query_test():
-    t.query(Tag("foo") & 5)
+    @raises(TypeError)
+    def func(t):
+        t.query(Tag("foo") & 5)
+
+    for backend in [MemoryBackend, TestRedisBackend]:
+        yield func, taxon.Taxon(backend())
 
 
-@with_setup(teardown=teardown)
 def encoding_test():
     import json
 
@@ -119,8 +158,9 @@ def encoding_test():
         def decode(self, data):
             return json.loads(data)
 
-    t = taxon.Taxon(JsonRedisBackend(Redis(db=db), 'jtxn'))
+    t = taxon.Taxon(JsonRedisBackend(redis_inst, 'jtxn'))
     t.tag('foo', {'foo': 'bar'})
     _, items = t.query(Tag('foo'))
     eq_(len(items), 1)
     ok_(isinstance(items[0], dict))
+    t.empty()


### PR DESCRIPTION
Right now Taxon is pretty tied to [Redis](http://redis.io), it is even called [redis-taxon on PyPI](http://pypi.python.org/pypi/redis-taxon/). Does it make sense to move toward an architecture where Taxon can be provided one of any number of backends that implement some `Backend` base class? I could imagine simple in-memory version as a reference implementation, a Redis version, and maybe one of the options from the [Data Persistence](http://docs.python.org/library/persistence.html) section of the standard library as "official" backends.

Attached is a rough but functional example of the Redis backend. Even if this branch doesn't get merged I'd like to discuss options and possibilities here.
